### PR TITLE
Additional settings

### DIFF
--- a/_build/data/properties.inc.php
+++ b/_build/data/properties.inc.php
@@ -215,21 +215,28 @@ $properties = array(
     ),
     array(
         'name' => 'skin',
-        'desc' => 'This option enables you to specify what skin you want to use with your theme. A skin is basically a CSS file that gets loaded from the skins directory inside the theme. The advanced theme that TinyMCE comes with has two skins these are called "default" and "o2k7".',
+        'desc' => 'This option enables you to specify what skin you want to use with your theme. A skin is basically a CSS file that gets loaded from the skins directory inside the theme. The advanced theme that TinyMCE comes with has two skins, these are called "default" and "o2k7". We added another skin named "cirkuit" that is chosen by default.',
         'type' => 'textfield',
         'options' => '',
         'value' => 'cirkuit',
     ),
     array(
         'name' => 'skin_variant',
-        'desc' => 'This option enables you to specify a variant for the skin, for example "silver" or "black". "default" skin does not offer any variant, whereas "o2k7" default offers "silver" or "black" variants to the default one. When creating a skin, additional variants may also be created, by adding ui_[variant_name].css files alongside the default ui.css.',
+        'desc' => 'This option enables you to specify a variant for the skin, for example "silver" or "black". "default" skin does not offer any variant, whereas "o2k7" default offers "silver" or "black" variants to the default one. For the "cirkuit" skin there\'s one variant named "silver". When creating a skin, additional variants may also be created, by adding ui_[variant_name].css files alongside the default ui.css.',
         'type' => 'textfield',
         'options' => '',
         'value' => '',
     ),
     array(
+        'name' => 'object_resizing',
+        'desc' => 'This option gives you the ability to turn on/off the inline resizing controls of tables and images in Firefox/Mozilla. These are enabled by default.',
+        'type' => 'combo-boolean',
+        'options' => '',
+        'value' => true,
+    ),
+    array(
         'name' => 'table_inline_editing',
-        'desc' => '',
+        'desc' => 'This option gives you the ability to turn on/off the inline table editing controls in Firefox/Mozilla. According to the TinyMCE documentation, these controls are somewhat buggy and not redesignable, so they are disabled by default.',
         'type' => 'combo-boolean',
         'options' => '',
         'value' => true,
@@ -300,6 +307,13 @@ This option enables you to specify where the toolbar should be located. This opt
         'type' => 'textfield',
         'options' => '',
         'value' => '95%',
+    ),
+    array(
+        'name' => 'template_selected_content_classes',
+        'desc' => 'Specify a list of CSS class names for the template plugin. They must be separated by spaces. Any template element with one of the specified CSS classes will have its content replaced by the selected editor content when first inserted.',
+        'type' => 'textfield',
+        'options' => '',
+        'value' => '',
     ),
 );
 

--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -113,5 +113,50 @@ $settings['tiny.theme_advanced_blockformats']->fromArray(array(
     'area' => 'tinymce',
 ),'',true,true);
 
+$settings['tiny.skin']= $modx->newObject('modSystemSetting');
+$settings['tiny.skin']->fromArray(array(
+    'key' => 'tiny.skin',
+    'value' => 'cirkuit',
+    'xtype' => 'textfield',
+    'namespace' => 'tinymce',
+    'area' => 'tinymce',
+),'',true,true);
+
+$settings['tiny.skin_variant']= $modx->newObject('modSystemSetting');
+$settings['tiny.skin_variant']->fromArray(array(
+    'key' => 'tiny.skin_variant',
+    'value' => '',
+    'xtype' => 'textfield',
+    'namespace' => 'tinymce',
+    'area' => 'tinymce',
+),'',true,true);
+
+$settings['tiny.object_resizing']= $modx->newObject('modSystemSetting');
+$settings['tiny.object_resizing']->fromArray(array(
+    'key' => 'tiny.object_resizing',
+    'value' => true,
+    'xtype' => 'combo-boolean',
+    'namespace' => 'tinymce',
+    'area' => 'tinymce',
+),'',true,true);
+
+$settings['tiny.table_inline_editing']= $modx->newObject('modSystemSetting');
+$settings['tiny.table_inline_editing']->fromArray(array(
+    'key' => 'tiny.table_inline_editing',
+    'value' => true,
+    'xtype' => 'combo-boolean',
+    'namespace' => 'tinymce',
+    'area' => 'tinymce',
+),'',true,true);
+
+$settings['tiny.template_selected_content_classes']= $modx->newObject('modSystemSetting');
+$settings['tiny.template_selected_content_classes']->fromArray(array(
+    'key' => 'tiny.template_selected_content_classes',
+    'value' => '',
+    'xtype' => 'textfield',
+    'namespace' => 'tinymce',
+    'area' => 'tinymce',
+),'',true,true);
+
 
 return $settings;

--- a/assets/components/tinymce/jscripts/tiny_mce/plugins/modxlink/langs/de.js
+++ b/assets/components/tinymce/jscripts/tiny_mce/plugins/modxlink/langs/de.js
@@ -1,3 +1,3 @@
 tinyMCE.addI18n('de.modxlink',{
-    link_desc:"Insert/edit link"
+    link_desc:"Link einf\u00FCgen/bearbeiten"
 });

--- a/assets/components/tinymce/jscripts/tiny_mce/plugins/modxlink/langs/de_dlg.js
+++ b/assets/components/tinymce/jscripts/tiny_mce/plugins/modxlink/langs/de_dlg.js
@@ -1,55 +1,54 @@
 tinyMCE.addI18n('de.modxlink_dlg',{
-title:"Link einf\u00FCgen/bearbeiten",
-url:"Adresse",
-target:"Fenster",
-titlefield:"Titel",
-is_email:"Diese Adresse scheint eine E-Mail-Adresse zu sein. M\u00F6chten Sie das dazu ben\u00F6tigte \"mailto:\" voranstellen?",
-is_external:"Diese Adresse scheint ein externer Link zu sein. M\u00F6chten Sie das dazu ben\u00F6tigte \"http://\" voranstellen?",
-list:"Linkliste",
-general_tab:"Allgemein",
-popup_tab:"Popup",
-events_tab:"Ereignisse",
-advanced_tab:"Erweitert",
-general_props:"Allemeine Eigenschaften",
-popup_props:"Popup-Eigenschaften",
-event_props:"Ereignisse",
-advanced_props:"Erweiterte Eigenschaften",
-popup_opts:"Optionen",
-anchor_names:"Anker",
-target_same:"Im selben Fenster/Frame \u00F6ffnen",
-target_parent:"Im \u00FCbergeordneten Fenster/Frame \u00F6ffnen",
-target_top:"Im obersten Frame \u00F6ffnen (sprengt das Frameset)",
-target_blank:"In neuem Fenster \u00F6ffnen",
-popup:"JavaScript-Popup",
-popup_url:"Popup-Adresse",
-popup_name:"Name des Fensters",
-popup_return:"Link trotz Popup folgen",
-popup_scrollbars:"Scrollbalken anzeigen",
-popup_statusbar:"Statusleiste anzeigen",
-popup_toolbar:"Werkzeugleisten anzeigen",
-popup_menubar:"Browsermen\u00FC anzeigen",
-popup_location:"Adressleiste anzeigen",
-popup_resizable:"Vergr\u00F6\u00DFern des Fenster zulassen",
-popup_dependent:"Vom Elternfenster abh\u00E4ngig <br /> (nur Mozilla/Firefox) ",
-popup_size:"Gr\u00F6\u00DFe",
-popup_position:"Position (X/Y)",
-id:"ID",
-style:"Format",
-classes:"Klassen",
-target_name:"Name der Zielseite",
-langdir:"Schriftrichtung",
-target_langcode:"Sprache der Zielseite",
-langcode:"Sprachcode",
-encoding:"Zeichenkodierung der Zielseite",
-mime:"MIME-Type der Zielseite",
-rel:"Beziehung der Seite zum Linkziel",
-rev:"Beziehung des Linkziels zur Seite",
-tabindex:"Tabindex",
-accesskey:"Tastenk\u00FCrzel",
-ltr:"Links nach rechts",
-rtl:"Rechts nach links",
-link_list:"Linkliste"
-,pagetitle: 'Pagetitle'
-,alias: 'Alias'
-,search: 'Search'
+title:"Link einf\u00FCgen/bearbeiten"
+,url:"Adresse"
+,target:"Fenster"
+,titlefield:"Titel"
+,is_email:"Diese Adresse scheint eine E-Mail-Adresse zu sein. M\u00F6chten Sie das dazu ben\u00F6tigte \"mailto:\" voranstellen?"
+,is_external:"Diese Adresse scheint ein externer Link zu sein. M\u00F6chten Sie das dazu ben\u00F6tigte \"http://\" voranstellen?"
+,general_tab:"Allgemein"
+,popup_tab:"Popup"
+,events_tab:"Ereignisse"
+,advanced_tab:"Erweitert"
+,general_props:"Allemeine Eigenschaften"
+,popup_props:"Popup-Eigenschaften"
+,event_props:"Ereignisse"
+,advanced_props:"Erweiterte Eigenschaften"
+,popup_opts:"Optionen"
+,anchor_names:"Anker"
+,target_same:"Im selben Fenster/Frame \u00F6ffnen"
+,target_parent:"Im \u00FCbergeordneten Fenster/Frame \u00F6ffnen"
+,target_top:"Im obersten Frame \u00F6ffnen (sprengt das Frameset)"
+,target_blank:"In neuem Fenster \u00F6ffnen"
+,popup:"JavaScript-Popup"
+,popup_url:"Popup-Adresse"
+,popup_name:"Name des Fensters"
+,popup_return:"Link trotz Popup folgen"
+,popup_scrollbars:"Scrollbalken anzeigen"
+,popup_statusbar:"Statusleiste anzeigen"
+,popup_toolbar:"Werkzeugleisten anzeigen"
+,popup_menubar:"Browsermen\u00FC anzeigen"
+,popup_location:"Adressleiste anzeigen"
+,popup_resizable:"Vergr\u00F6\u00DFern des Fenster zulassen"
+,popup_dependent:"Vom Elternfenster abh\u00E4ngig <br /> (nur Mozilla/Firefox) "
+,popup_size:"Gr\u00F6\u00DFe"
+,popup_position:"Position (X/Y)"
+,id:"ID"
+,style:"Format"
+,classes:"Klassen"
+,target_name:"Name der Zielseite"
+,langdir:"Schriftrichtung"
+,target_langcode:"Sprache der Zielseite"
+,langcode:"Sprachcode"
+,encoding:"Zeichenkodierung der Zielseite"
+,mime:"MIME-Type der Zielseite"
+,rel:"Beziehung der Seite zum Linkziel"
+,rev:"Beziehung des Linkziels zur Seite"
+,tabindex:"Tabindex"
+,accesskey:"Tastenk\u00FCrzel"
+,ltr:"Links nach rechts"
+,rtl:"Rechts nach links"
+,link_list:"Linkliste"
+,pagetitle:"Seitentitel"
+,alias:"Alias"
+,search:"Seite suchen"
 });

--- a/assets/components/tinymce/jscripts/tiny_mce/plugins/modxlink/langs/en_dlg.js
+++ b/assets/components/tinymce/jscripts/tiny_mce/plugins/modxlink/langs/en_dlg.js
@@ -48,7 +48,7 @@ title:"Insert/edit link"
 ,ltr:"Left to right"
 ,rtl:"Right to left"
 ,link_list:"Link list"
-,pagetitle: 'Pagetitle'
-,alias: 'Alias'
-,search: 'Search'
+,pagetitle:"Pagetitle"
+,alias:"Alias"
+,search:"Search"
 });

--- a/assets/components/tinymce/tinymce.panel.js
+++ b/assets/components/tinymce/tinymce.panel.js
@@ -34,7 +34,7 @@ Tiny.Editor = function(config) {
         ,remove_line_breaks: false
         ,resource_browser_path: Tiny.config.manager_url+'controllers/browser/index.php?'
         ,width: '90%'
-        
+
         ,buttons1: MODx.config['tiny.custom_buttons1']
         ,buttons2: MODx.config['tiny.custom_buttons2']
         ,buttons3: MODx.config['tiny.custom_buttons3']
@@ -42,7 +42,7 @@ Tiny.Editor = function(config) {
         ,css_path: MODx.config['editor_css_path'] || ''
         ,css_selectors: MODx.config['tinymce.css_selectors']
         ,plugins: MODx.config['tiny.custom_plugins']
-        
+
         ,theme: MODx.config['tiny.editor_theme'] || 'advanced'
         ,theme_advanced_buttons1: MODx.config['tiny.custom_buttons1']
         ,theme_advanced_buttons2: MODx.config['tiny.custom_buttons2']
@@ -55,9 +55,15 @@ Tiny.Editor = function(config) {
         ,theme_advanced_toolbar_align: 'left'
         ,theme_advanced_disable: ''
         ,theme_advanced_toolbar_location: 'top'
-        
+
         ,toolbar_align: MODx.config['manager_direction'] || 'rtl'
         ,use_browser: MODx.config['use_browser'] || true
+
+        ,skin: MODx.config['tiny.skin']
+        ,skin_variant: MODx.config['tiny.skin_variant']
+        ,object_resizing: MODx.config['tiny.object_resizing'] || true
+        ,table_inline_editing: MODx.config['tiny.table_inline_editing'] || true
+        ,template_selected_content_classes: MODx.config['tiny.template_selected_content_classes']
     });
     Ext.applyIf(config,{
         width: '90%'
@@ -73,27 +79,27 @@ Tiny.Editor = function(config) {
 };
 Ext.extend(Tiny.Editor,Ext.form.TextArea,{
     editor: null
-    
+
     ,getTinyId: function() {
         return this.getEl().dom.id;
     }
-    
+
     ,setValue: function(v) {
         var c = tinyMCE.get(this.getTinyId());
-        if (c) c.setContent(v);        
+        if (c) c.setContent(v);
     }
-    
+
     ,onTinyRender: function() {
         var oid = Ext.get(this.getTinyId());
         if (!oid) return;
-        
+
         var s = this.config.tinyConfig;
         s.mode = 'exact';
         tinyMCE.init(s);
         tinyMCE.execCommand('mceAddControl', false,this.getTinyId());
         this.fireEvent('load');
     }
-    
+
     ,onChange: function() {}
     ,onLoad: function(ed) {
         return false;
@@ -115,7 +121,7 @@ Ext.extend(Tiny.Editor,Ext.form.TextArea,{
             el = Ext.get(el);
             tinyMCE.execCommand('mceAddControl', false, el.dom.id);
         },this);
-                
+
         this.fireEvent('ajaxload');
     }
     ,toggle: function(e,t) {

--- a/core/components/tinymce/lexicon/de/default.inc.php
+++ b/core/components/tinymce/lexicon/de/default.inc.php
@@ -1,28 +1,42 @@
 <?php
-/*
- * Filename:       assets/plugins/tinymce/lang/german.inc.php
- * Function:       German language file for TinyMCE.  Needs to be translated and re-encoded!
- * Encoding:       ISO-Latin-1
- * Author:         Jeff Whitfield
- * Date:           2007/01/06
- * Version:        2.0.9
- * MODx version:   0.9.5
-*/
-
-include_once(dirname(__FILE__).'/english.inc.php'); // fallback for missing defaults or new additions
-
-$_lang['tinymce_editor_theme_title'] = "Theme:";
-$_lang['tinymce_editor_theme_message'] = "Here you can select which theme or skin to use with the editor.";
-$_lang['tinymce_editor_custom_plugins_title'] = "Custom Plugins:";
-$_lang['tinymce_editor_custom_plugins_message'] = "Enter the plugins to use for the 'custom' theme as a comma separated list.";
-$_lang['tinymce_editor_custom_buttons_title'] = "Custom Buttons:";
-$_lang['tinymce_editor_custom_buttons_message'] = "Enter the buttons to use for the 'custom' theme as a comma separated list for each row. Be sure that each button has the required plugin enabled in the 'Custom Plugins' setting.";
-$_lang['tinymce_editor_css_selectors_title'] = "CSS selectors:";
-$_lang['tinymce_editor_css_selectors_message'] = "Here you can enter a list of selectors that should be available in the editor. Enter them as follows:<br />'displayName=selectorName;displayName2=selectorName2'<br />For instance, say you have <b>.mono</b> and <b>.smallText</b> selectors in your CSS file, you could add them here as:<br />'Monospaced text=mono;Small text=smallText'<br />Note that the last entry should not have a semi-colon after it.";
-$_lang['tinymce_settings'] = "TinyMCE Settings";
-$_lang['tinymce_theme_simple'] = "Simple";
-$_lang['tinymce_theme_advanced'] = "Advanced";
-$_lang['tinymce_theme_editor'] = "Content Editor";
-$_lang['tinymce_theme_custom'] = "Custom";
+/**
+ * Default TinyMCE language file
+ *
+ * @package tinymce
+ * @language de
+ */
+$_lang['tiny.toggle_editor'] = 'Editor ein- und ausschalten: ';
+$_lang['setting_tiny.css_selectors'] = 'CSS-Selektoren';
+$_lang['setting_tiny.css_selectors_desc'] = 'Hier können Sie eine Liste von Selektoren eingeben, die im Editor verfügbar sein sollen. Geben Sie sie folgendermaßen ein:<br />"angezeigterName=selektorName;angezeigterName2=selektorName2"<br />Wenn Sie zum Beispiel die Selektoren <b>.mono</b> und <b>.smallText</b> in Ihrer CSS-Datei haben, können Sie sie hier so hinzufügen:<br />"Monospace-Text=mono;Kleiner Text=smallText"<br />Beachten Sie, dass hinter dem letzten Eintrag kein Semikolon stehen sollte.';
+$_lang['setting_tiny.custom_buttons1'] = 'Selbstdefinierte Button-Zeile 1';
+$_lang['setting_tiny.custom_buttons1_desc'] = 'Geben Sie die für die erste Zeile zu verwendenden Buttons als kommaseparierte Liste ein. Stellen Sie sicher, dass für jeden Button das benötigte Plugin in der Einstellung "Zu verwendende Plugins" aktiviert ist.';
+$_lang['setting_tiny.custom_buttons2'] = 'Selbstdefinierte Button-Zeile 2';
+$_lang['setting_tiny.custom_buttons2_desc'] = 'Geben Sie die für die zweite Zeile zu verwendenden Buttons als kommaseparierte Liste ein. Stellen Sie sicher, dass für jeden Button das benötigte Plugin in der Einstellung "Zu verwendende Plugins" aktiviert ist.';
+$_lang['setting_tiny.custom_buttons3'] = 'Selbstdefinierte Button-Zeile 3';
+$_lang['setting_tiny.custom_buttons3_desc'] = 'Geben Sie die für die dritte Zeile zu verwendenden Buttons als kommaseparierte Liste ein. Stellen Sie sicher, dass für jeden Button das benötigte Plugin in der Einstellung "Zu verwendende Plugins" aktiviert ist.';
+$_lang['setting_tiny.custom_buttons4'] = 'Selbstdefinierte Button-Zeile 4';
+$_lang['setting_tiny.custom_buttons4_desc'] = 'Geben Sie die für die vierte Zeile zu verwendenden Buttons als kommaseparierte Liste ein. Stellen Sie sicher, dass für jeden Button das benötigte Plugin in der Einstellung "Zu verwendende Plugins" aktiviert ist.';
+$_lang['setting_tiny.custom_buttons5'] = 'Selbstdefinierte Button-Zeile 5';
+$_lang['setting_tiny.custom_buttons5_desc'] = 'Geben Sie die für die fünfte Zeile zu verwendenden Buttons als kommaseparierte Liste ein. Stellen Sie sicher, dass für jeden Button das benötigte Plugin in der Einstellung "Zu verwendende Plugins" aktiviert ist.';
+$_lang['setting_tiny.custom_plugins'] = 'Zu verwendende Plugins';
+$_lang['setting_tiny.custom_plugins_desc'] = 'Eine kommaseparierte Liste der zu verwendenden TinyMCE-Plugins.';
+$_lang['setting_tiny.editor_theme'] = 'Editor-Theme';
+$_lang['setting_tiny.template_list'] = 'Template-Liste';
+$_lang['setting_tiny.template_list_desc'] = 'Geben Sie eine Liste von Templates für das Template-Plugin ein. Die Einträge müssen durch Kommata getrennt sein und das Format Name:URL:Beschreibung haben. Beispiel: MeinTemplate:assets/templates/mytemp.html:Mein eigenes Template';
+$_lang['setting_tiny.path_options'] = 'Pfad-Optionen';
+$_lang['setting_tiny.path_options_desc'] = 'Mögliche Werte: "rootrelative", "docrelative" oder "fullpathurl".';
+$_lang['setting_tiny.use_uncompressed_library'] = 'Unkomprimierte Bibliothek verwenden';
+$_lang['setting_tiny.use_uncompressed_library_desc'] = 'Wenn diese Einstellung aktiviert ist, verwendet MODx nicht die komprimierte TinyMCE-JavaScript-Bibliothek. Dies verursacht mehr Last und erhöht die Ausführungszeit. Aktivieren Sie diese Einstellung nur, wenn Sie Modifikationen vornehmen möchten.';
 $_lang['setting_tiny.theme_advanced_blockformats'] = 'HTML-Blockelemente';
-$_lang['setting_tiny.theme_advanced_blockformats_desc'] = 'Eine kommaseparierte Liste von HTML-Blockelementen. Mögliche Werte sind: p, h1, h2, h3, h4, h5, h6, div, blockquote, code, pre, address.';
+$_lang['setting_tiny.theme_advanced_blockformats_desc'] = 'Diese Einstellung sollte eine kommaseparierte Liste von HTML-Blockelementen enthalten, die in dem Drop-Down-Feld "Vorlage" angezeigt werden sollen. Diese Option ist nur verfügbar, wenn das Theme "advanced" verwendet wird. Mögliche Werte sind z. B.: p, h1, h2, h3, h4, h5, h6, div, blockquote, code, pre, address.';
+
+$_lang['setting_tiny.skin'] = 'TinyMCE-Skin';
+$_lang['setting_tiny.skin_desc'] = 'Diese Einstellung ermöglicht es Ihnen, anzugeben, welchen Skin Sie mit Ihrem TinyMCE-Editor-Theme verwenden möchten. Ein Skin ist im Grunde eine CSS-Datei, die aus dem Skins-Verzeichnis in das Theme geladen wird. Das Theme "advanced", das mit TinyMCE ausgeliefert wird, hat zwei Skins; diese heißen "default" und "o2k7". Wir haben einen weiteren Skin namens "cirkuit" hinzugefügt, der standardmäßig vorausgewählt ist.';
+$_lang['setting_tiny.skin_variant'] = 'TinyMCE-Skin-Variante';
+$_lang['setting_tiny.skin_variant_desc'] = 'Einige Skins haben eine oder mehrere zusätzliche Varianten, die man auswählen kann. Der Skin "cirkuit" besitzt die zusätzliche Variante "silver", für den Skin "o2k7" stehen die zusätzlichen Varianten "black" und "silver" zur Verfügung. Standardmäßig ist diese Einstellung leer.';
+$_lang['setting_tiny.object_resizing'] = 'Objekt-Größenänderung im Editor';
+$_lang['setting_tiny.object_resizing_desc'] = 'Diese Option gibt Ihnen die Möglichkeit, die Größenänderungs-Kontrollelemente von Tabellen und Bildern in Firefox/Mozilla ein- und auszuschalten. Standardmäßig sind diese eingeschaltet.';
+$_lang['setting_tiny.table_inline_editing'] = 'Tabellen-Bearbeitung';
+$_lang['setting_tiny.table_inline_editing_desc'] = 'Diese Option gibt Ihnen die Möglichkeit, die Kontrollelemente für die Inline-Bearbeitung von Tabellen in Firefox/Mozilla ein- und auszuschalten. Laut der TinyMCE-Dokumentation sind diese Kontrollelemente nicht ganz fehlerfrei und nicht änderbar, daher sind sie standardmäßig deaktiviert.';
+$_lang['setting_tiny.template_selected_content_classes'] = 'Template-CSS-Klassen für markierte Inhalte';
+$_lang['setting_tiny.template_selected_content_classes_desc'] = 'Geben Sie eine Liste von CSS-Klassennamen für das Template-Plugin ein. Die Einträge müssen durch Leerzeichen getrennt sein. Der Inhalt jedes Vorlagen-Elements mit einer der angegebenen CSS-Klassen wird durch die im Editor markierten Inhalte ersetzt, wenn die Vorlage eingefügt wird.';

--- a/core/components/tinymce/lexicon/en/default.inc.php
+++ b/core/components/tinymce/lexicon/en/default.inc.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Default TinyMCE language file
- * 
+ *
  * @package tinymce
  * @language en
  */
@@ -27,3 +27,14 @@ $_lang['setting_tiny.path_options'] = 'Path Options';
 $_lang['setting_tiny.path_options_desc'] = 'Either "rootrelative", "docrelative", or "fullpathurl".';
 $_lang['setting_tiny.theme_advanced_blockformats'] = 'HTML Block Elements';
 $_lang['setting_tiny.theme_advanced_blockformats_desc'] = 'This option should contain a comma separated list of formats that will be available in the format drop down list. This option is only available if the advanced theme is used.';
+
+$_lang['setting_tiny.skin'] = 'TinyMCE Skin';
+$_lang['setting_tiny.skin_desc'] = 'This option enables you to specify what skin you want to use with your theme. A skin is basically a CSS file that gets loaded from the skins directory inside the theme. The advanced theme that TinyMCE comes with has two skins, these are called "default" and "o2k7". We added another skin named "cirkuit" that is chosen by default.';
+$_lang['setting_tiny.skin_variant'] = 'TinyMCE Skin Variant';
+$_lang['setting_tiny.skin_variant_desc'] = 'This option enables you to specify a variant for the skin, for example "silver" or "black". "default" skin does not offer any variant, whereas "o2k7" default offers "silver" or "black" variants to the default one. For the "cirkuit" skin there\'s one variant named "silver". When creating a skin, additional variants may also be created, by adding ui_[variant_name].css files alongside the default ui.css.';
+$_lang['setting_tiny.object_resizing'] = 'Object Resizing';
+$_lang['setting_tiny.object_resizing_desc'] = 'This option gives you the ability to turn on/off the inline resizing controls of tables and images in Firefox/Mozilla. These are enabled by default.';
+$_lang['setting_tiny.table_inline_editing'] = 'Table Inline Editing';
+$_lang['setting_tiny.table_inline_editing_desc'] = 'This option gives you the ability to turn on/off the inline table editing controls in Firefox/Mozilla. According to the TinyMCE documentation, these controls are somewhat buggy and not redesignable, so they are disabled by default.';
+$_lang['setting_tiny.template_selected_content_classes'] = 'Template Selected Content Classes';
+$_lang['setting_tiny.template_selected_content_classes_desc'] = 'Specify a list of CSS class names for the template plugin. They must be separated by spaces. Any template element with one of the specified CSS classes will have its content replaced by the selected editor content when first inserted.';

--- a/core/components/tinymce/tinymce.class.php
+++ b/core/components/tinymce/tinymce.class.php
@@ -50,9 +50,9 @@ class TinyMCE {
             'force_br_newlines' => false,
             'forced_root_block' => false,
             'formats' => array(
-		'alignleft' => array('selector' => 'p,h1,h2,h3,h4,h5,h6,td,th,div,ul,ol,li,table,img', 'classes' => 'justifyleft'),
-		'alignright' => array('selector' => 'p,h1,h2,h3,h4,h5,h6,td,th,div,ul,ol,li,table,img', 'classes' => 'justifyright'),
-		'alignfull' => array('selector' => 'p,h1,h2,h3,h4,h5,h6,td,th,div,ul,ol,li,table,img', 'classes' => 'justifyfull'),
+                'alignleft' => array('selector' => 'p,h1,h2,h3,h4,h5,h6,td,th,div,ul,ol,li,table,img', 'classes' => 'justifyleft'),
+                'alignright' => array('selector' => 'p,h1,h2,h3,h4,h5,h6,td,th,div,ul,ol,li,table,img', 'classes' => 'justifyright'),
+                'alignfull' => array('selector' => 'p,h1,h2,h3,h4,h5,h6,td,th,div,ul,ol,li,table,img', 'classes' => 'justifyfull'),
             ),
             'frontend' => false,
             'height' => '400px',
@@ -103,6 +103,12 @@ class TinyMCE {
             'use_browser' => $this->modx->getOption('use_browser',$this->properties,true),
             'path_options' => $this->modx->getOption('tiny.path_options',$this->properties,''),
             'language' => $this->modx->getOption('manager_language',null,$this->modx->getOption('cultureKey',null,'en')),
+
+            'skin' => $this->modx->getOption('tiny.skin',$this->properties,''),
+            'skin_variant' => $this->modx->getOption('tiny.skin_variant',$this->properties,''),
+            'object_resizing' => $this->modx->getOption('tiny.object_resizing',$this->properties,true),
+            'table_inline_editing' => $this->modx->getOption('tiny.table_inline_editing',$this->properties,true),
+            'template_selected_content_classes' => $this->modx->getOption('tiny.template_selected_content_classes',$this->properties,''),
         ));
     }
 
@@ -175,7 +181,7 @@ class TinyMCE {
             $this->properties['resource'] = $this->properties['resource']->toArray();
         }
         //unset($this->properties['width'],$this->properties['height']);
-        
+
         $templates = $this->getTemplateList();
 
         /* get formats */


### PR DESCRIPTION
Added additional settings for TinyMCE:
- skin
- skin_variant
- object_resizing
- table_inline_editing
- template_selected_content_classes

English and German phrases are included.

See https://github.com/splittingred/TinyMCE/issues#issue/21
