### PR TITLE
[#8482] RTE Output Option for TVs does not render RTE on frontend

### DIFF
--- a/core/components/tinymce/templates/fe_script.tpl
+++ b/core/components/tinymce/templates/fe_script.tpl
@@ -1,0 +1,3 @@
+<script type="text/javascript">
+    tinyMCE.init(<?php echo $this->modx->toJSON($this->properties); ?>);
+</script>

--- a/core/components/tinymce/tinymce.class.php
+++ b/core/components/tinymce/tinymce.class.php
@@ -139,7 +139,7 @@ class TinyMCE {
     public function initialize() {
         if (!$this->jsLoaded) {
             $scriptFile = ((!$this->properties['frontend'] && $this->properties['compressor'] == 'enabled') ? 'tiny_mce_gzip.php' : 'tiny_mce.js');
-            if ($this->context->getOption('tiny.use_uncompressed_library',false)) {
+            if ($this->context->getOption('tiny.use_uncompressed_library',true)) {
                 $scriptFile = 'tiny_mce_src.js';
             }
             $this->modx->lexicon->load('tinymce:default');
@@ -150,15 +150,17 @@ class TinyMCE {
 
             $this->modx->regClientStartupScript($this->config['assetsUrl'].'jscripts/tiny_mce/'.$scriptFile);
             $this->modx->regClientStartupScript($this->config['assetsUrl'].'xconfig.js');
-            if ($compressJs) {
-                $this->modx->regClientStartupScript($this->config['assetsUrl'].'tiny.min.js');
-            } else {
-                $this->modx->regClientStartupScript($this->config['assetsUrl'].'tiny.js');
+            if(!$this->properties['frontend']) {                
+                if ($compressJs) {
+                    $this->modx->regClientStartupScript($this->config['assetsUrl'].'tiny.min.js');
+                } else {
+                    $this->modx->regClientStartupScript($this->config['assetsUrl'].'tiny.js');
+                }
             }
 
             $source = $this->context->getOption('default_media_source',1);
-            $this->modx->regClientStartupHTMLBlock('<script type="text/javascript">' . "\n//<![CDATA[" .  "\nvar inRevo20 = ".($inRevo20 ? 1 : 0).";MODx.source = '".$source."';Tiny.lang = "  . $this->modx->toJSON($lang). ';' . "\n//]]>" . "\n</script>");
-            if (!$compressJs) {
+            if (!$this->properties['frontend']) $this->modx->regClientStartupHTMLBlock('<script type="text/javascript">' . "\n//<![CDATA[" .  "\nvar inRevo20 = ".($inRevo20 ? 1 : 0).";MODx.source = '".$source."';Tiny.lang = "  . $this->modx->toJSON($lang). ';' . "\n//]]>" . "\n</script>");
+            if (!$compressJs && !$this->properties['frontend']) {
                 $this->modx->regClientStartupScript($this->config['assetsUrl'].'tinymce.panel.js');
             }
 
@@ -236,10 +238,14 @@ class TinyMCE {
         //$this->properties['formats'] = $this->getFormats();
         /* get JS */
         unset($this->properties['resource']);
-        ob_start();
-        include_once dirname(__FILE__).'/templates/script.tpl';
-        $script = ob_get_contents();
-        ob_end_clean();
+            ob_start();
+            if (!$this->properties['frontend']) {
+                include_once dirname(__FILE__).'/templates/script.tpl';
+            } else {
+                include_once dirname(__FILE__).'/templates/fe_script.tpl';
+            }
+            $script = ob_get_contents();
+            ob_end_clean();
 
         /* will need to do $this->modx->controller->addHtml() for Revo 2.2+ */
         $this->modx->regClientStartupHTMLBlock($script);

--- a/core/components/tinymce/tinymce.plugin.php
+++ b/core/components/tinymce/tinymce.plugin.php
@@ -29,16 +29,21 @@ switch ($modx->event->name) {
     case 'OnRichTextEditorInit':
         if ($useEditor && $whichEditor == 'TinyMCE') {
             unset($scriptProperties['chunk']);
-            if (isset($forfrontend) || $modx->context->get('key') != 'mgr') {
+            $tiny->setProperties($scriptProperties);
+            if ((isset($tiny->properties['frontend']) && $tiny->properties['frontend'] == true) || $modx->context->get('key') != 'mgr') {
                 $def = $tiny->context->getOption('cultureKey',$tiny->context->getOption('manager_language','en'));
                 $tiny->properties['language'] = $modx->getOption('fe_editor_lang',array(),$def);
+                $tiny->properties['mode'] = 'exact';
+                $tiny->properties['elements'] = implode(',',$scriptProperties['elements']);
+                $tiny->properties['execcommand_callback'] = '';
+                $tiny->properties['file_browser_callback'] = '';
+                $tiny->properties['use_browser'] = false;
                 $tiny->properties['frontend'] = true;
                 unset($def);
             }
             /* commenting these out as it causes problems with richtext tvs */
             //if (isset($scriptProperties['resource']) && !$resource->get('richtext')) return;
             //if (!isset($scriptProperties['resource']) && !$modx->getOption('richtext_default',null,false)) return;
-            $tiny->setProperties($scriptProperties);
             $html = $tiny->initialize();
             $modx->event->output($html);
             unset($html);
@@ -49,9 +54,9 @@ switch ($modx->event->name) {
             $inRevo20 = (boolean)version_compare($modx->version['full_version'],'2.1.0-rc1','<');
             $modx->getVersionData();
             $source = $tiny->context->getOption('default_media_source',null,1);
-            
-            $modx->controller->addHtml('<script type="text/javascript">var inRevo20 = '.($inRevo20 ? 1 : 0).';MODx.source = "'.$source.'";</script>');
-            
+            if (!isset($tiny->properties['frontend'])) {
+                $modx->controller->addHtml('<script type="text/javascript">var inRevo20 = '.($inRevo20 ? 1 : 0).';MODx.source = "'.$source.'";</script>');
+            }
             $modx->controller->addJavascript($tiny->config['assetsUrl'].'jscripts/tiny_mce/tiny_mce_popup.js');
             if (file_exists($tiny->config['assetsPath'].'jscripts/tiny_mce/langs/'.$tiny->properties['language'].'.js')) {
                 $modx->controller->addJavascript($tiny->config['assetsUrl'].'jscripts/tiny_mce/langs/'.$tiny->properties['language'].'.js');


### PR DESCRIPTION
This fixes the bug where TinyMCE will not work on the frontend when specified as a TV output option. Please note, there is a related core fix as well to get this working so this will require 2.2.5+ to work fully:

https://github.com/modxcms/revolution/commit/b93b2dec3c9885e588e0915a31aa4ab2a4137d6a
