### PR TITLE
Update ui.css

### DIFF
--- a/assets/components/tinymce/jscripts/tiny_mce/themes/advanced/skins/cirkuit/ui.css
+++ b/assets/components/tinymce/jscripts/tiny_mce/themes/advanced/skins/cirkuit/ui.css
@@ -973,7 +973,7 @@
 	background-position: 0 -40px
 }
 
-.cirkuitSkin .mce_spellchecker span.mceAction {
+.cirkuitSkin span.mce_spellchecker {
 	background-position: -540px -20px
 }
 


### PR DESCRIPTION
previous css rule didn't work for spellchecker icon, now it's correct